### PR TITLE
use toString instead of cast when creating job param definitions

### DIFF
--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/sink/MantisKafkaProducerConfig.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/sink/MantisKafkaProducerConfig.java
@@ -109,7 +109,7 @@ public class MantisKafkaProducerConfig extends ProducerConfig {
                 .validator(Validators.alwaysPass())
                 .description(KafkaSinkJobParameters.PREFIX + key);
             if (defaultProps.containsKey(key)) {
-                builder = builder.defaultValue((String) defaultProps.get(key));
+                builder = builder.defaultValue(defaultProps.get(key).toString());
             }
             params.add(builder.build());
         }

--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfig.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfig.java
@@ -143,7 +143,7 @@ public class MantisKafkaConsumerConfig extends ConsumerConfig {
                 .validator(Validators.alwaysPass())
                 .description(KafkaSourceParameters.PREFIX + key);
             if (defaultProps.containsKey(key)) {
-                builder = builder.defaultValue((String) defaultProps.get(key));
+                builder = builder.defaultValue(defaultProps.get(key).toString());
             }
             params.add(builder.build());
         }

--- a/mantis-connector-kafka/src/test/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfigTest.java
+++ b/mantis-connector-kafka/src/test/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfigTest.java
@@ -31,7 +31,6 @@ import io.mantisrx.runtime.parameter.Parameters;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.requests.IsolationLevel;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 


### PR DESCRIPTION
### Context

use toString instead of cast when creating job param definitions
### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
