### PR TITLE
remove unused kafkaVip param

### DIFF
--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/KafkaSourceParameters.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/KafkaSourceParameters.java
@@ -23,7 +23,6 @@ public class KafkaSourceParameters {
     public static final String CONSUMER_POLL_TIMEOUT_MS = "consumerPollTimeoutMs";
     public static final String NUM_KAFKA_CONSUMER_PER_WORKER = "numKafkaConsumerPerWorker";
     public static final String TOPIC = PREFIX + "topic";
-    public static final String KAFKA_VIP = "kafkaVip";
     public static final String MAX_BYTES_IN_PROCESSING = "maxBytesInProcessing";
     public static final String PARSER_TYPE = "messageParserType";
     public static final String PARSE_MSG_IN_SOURCE = "parseMessageInKafkaConsumerThread";

--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/KafkaSource.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/KafkaSource.java
@@ -314,12 +314,6 @@ public class KafkaSource implements Source<KafkaAckable> {
                        .validator(Validators.notNullOrEmpty())
                        .required()
                        .build());
-        params.add(new StringParameter()
-                       .name(KafkaSourceParameters.KAFKA_VIP)
-                       .description("vip address of source Kafka cluster")
-                       .validator(Validators.notNullOrEmpty())
-                       .required()
-                       .build());
         // Optional parameters
         params.add(new StringParameter()
                        .name(KafkaSourceParameters.CHECKPOINT_STRATEGY)


### PR DESCRIPTION
### Context
remove unused kafkaVip param

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
