### PR TITLE
handle class values when generating job param definition

### DIFF
--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/sink/MantisKafkaProducerConfig.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/sink/MantisKafkaProducerConfig.java
@@ -109,7 +109,12 @@ public class MantisKafkaProducerConfig extends ProducerConfig {
                 .validator(Validators.alwaysPass())
                 .description(KafkaSinkJobParameters.PREFIX + key);
             if (defaultProps.containsKey(key)) {
-                builder = builder.defaultValue(defaultProps.get(key).toString());
+                Object value = defaultProps.get(key);
+                if (value instanceof Class) {
+                    builder = builder.defaultValue(((Class) value).getCanonicalName());
+                } else {
+                    builder = builder.defaultValue((String) value);
+                }
             }
             params.add(builder.build());
         }

--- a/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfig.java
+++ b/mantis-connector-kafka/src/main/java/io/mantisrx/connector/kafka/source/MantisKafkaConsumerConfig.java
@@ -143,7 +143,12 @@ public class MantisKafkaConsumerConfig extends ConsumerConfig {
                 .validator(Validators.alwaysPass())
                 .description(KafkaSourceParameters.PREFIX + key);
             if (defaultProps.containsKey(key)) {
-                builder = builder.defaultValue(defaultProps.get(key).toString());
+                Object value = defaultProps.get(key);
+                if (value instanceof Class) {
+                    builder = builder.defaultValue(((Class) value).getCanonicalName());
+                } else {
+                    builder = builder.defaultValue((String) value);
+                }
             }
             params.add(builder.build());
         }


### PR DESCRIPTION
### Context

handle class values when generating job param definition
### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
