### PR TITLE
Remove auto-create tables, improve writer init, add tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codyrioux @neerajrj @nickmahilani @jeffchao @piygoyal @skalidindi
+* @codyrioux @neerajrj @nickmahilani @jeffchao @piygoyal

--- a/mantis-connector-iceberg/README.md
+++ b/mantis-connector-iceberg/README.md
@@ -2,7 +2,7 @@
 
 Connector for working with [Iceberg](https://iceberg.apache.org/).
 
-```
+```groovy
 implementation "io.mantisrx:mantis-connector-iceberg:$icebergVersion"
 ```
 

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStage.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStage.java
@@ -136,7 +136,7 @@ public class IcebergCommitterStage implements ScalarComputation<DataFile, Map<St
                     .buffer(config.getCommitFrequencyMs(), TimeUnit.MILLISECONDS, scheduler)
                     .filter(dataFiles -> !dataFiles.isEmpty())
                     .map(committer::commit)
-                    .doOnNext(snapshot -> {
+                    .doOnNext(summary -> {
                         // metric
                     })
                     .onErrorResumeNext(throwable -> {

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
@@ -69,13 +69,12 @@ public abstract class BaseIcebergWriter implements IcebergWriter {
             WriterMetrics metrics,
             WriterConfig config,
             WorkerInfo workerInfo,
-            Table table,
-            PartitionSpec spec) {
+            Table table) {
         this.metrics = metrics;
         this.config = config;
 
         this.table = table;
-        this.spec = spec;
+        this.spec = table.spec();
         this.workerInfo = workerInfo;
         this.format = FileFormat.valueOf(config.getWriterFileFormat());
     }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -29,14 +29,11 @@ import io.mantisrx.runtime.ScalarToScalar;
 import io.mantisrx.runtime.WorkerInfo;
 import io.mantisrx.runtime.computation.ScalarComputation;
 import io.mantisrx.runtime.parameter.ParameterDefinition;
-import io.mantisrx.runtime.parameter.type.EnumParameter;
 import io.mantisrx.runtime.parameter.type.IntParameter;
 import io.mantisrx.runtime.parameter.type.StringParameter;
 import io.mantisrx.runtime.parameter.validator.Validators;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -54,7 +51,6 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
     private static final Logger logger = LoggerFactory.getLogger(IcebergWriterStage.class);
 
     private final WriterMetrics metrics;
-    private final Schema writerSchema;
 
     // TODO: Move to config.
     private final String[] tableIdentifierNames;
@@ -90,17 +86,6 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
                         .description(WriterProperties.WRITER_FILE_FORMAT_DESCRIPTION)
                         .validator(Validators.alwaysPass())
                         .defaultValue(WriterProperties.WRITER_FILE_FORMAT_DEFAULT)
-                        .build(),
-                new StringParameter().name(WriterProperties.WRITER_PARTITION_KEY)
-                        .description(WriterProperties.WRITER_PARTITION_KEY_DESCRIPTION)
-                        .validator(Validators.alwaysPass())
-                        .defaultValue(WriterProperties.WRITER_PARTITION_KEY_DEFAULT)
-                        .build(),
-                new EnumParameter<>(WriterProperties.PartitionTransforms.class)
-                        .name(WriterProperties.WRITER_PARTITION_KEY_TRANSFORM)
-                        .description(WriterProperties.WRITER_PARTITION_KEY_TRANSFORM_DESCRIPTION)
-                        .validator(Validators.alwaysPass())
-                        .defaultValue(WriterProperties.WRITER_PARTITION_KEY_TRANSFORM_DEFAULT)
                         .build()
         );
     }
@@ -117,49 +102,32 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
             WriterConfig config,
             WriterMetrics metrics,
             WorkerInfo workerInfo,
-            Table table,
-            Schema writerSchema) {
-        PartitionSpec.Builder specBuilder = PartitionSpec.builderFor(writerSchema);
-
-        // TODO: Support composite keys.
-        String key = config.getWriterPartitionKey();
-        switch (config.getWriterPartitionKeyTransform()) {
-            case IDENTITY:
-                specBuilder.identity(key);
-                break;
-            case YEAR:
-                specBuilder.year(key);
-                break;
-            case MONTH:
-                specBuilder.month(key);
-                break;
-            case DAY:
-                specBuilder.day(key);
-                break;
-            case HOUR:
-                specBuilder.hour(key);
-                break;
-            case NONE:
-                // Unpartitioned writer.
-            default:
-                // Unpartitioned writer.
-                break;
-        }
-        PartitionSpec spec = specBuilder.build();
-
-        if (spec.fields().isEmpty()) {
-            return new UnpartitionedIcebergWriter(metrics, config, workerInfo, table, spec);
+            Table table) {
+        if (table.spec().fields().isEmpty()) {
+            return new UnpartitionedIcebergWriter(metrics, config, workerInfo, table);
         } else {
-            return new PartitionedIcebergWriter(metrics, config, workerInfo, table, writerSchema, spec);
+            return new PartitionedIcebergWriter(metrics, config, workerInfo, table);
         }
     }
 
-    public IcebergWriterStage(Schema writerSchema, String... tableIdentifierNames) {
+    /**
+     * Creates a new Iceberg Writer Processing Stage using a table identifier.
+     */
+    public IcebergWriterStage(String... tableIdentifierNames) {
         this.metrics = new WriterMetrics();
-        this.writerSchema = writerSchema;
         this.tableIdentifierNames = tableIdentifierNames;
     }
 
+    /**
+     * Uses the provided Mantis Context to inject configuration and opens an underlying file appender.
+     *
+     * This method depends on a Hadoop Configuration and Iceberg Catalog, both injected
+     * from the Context's service locator.
+     *
+     * Note that this method expects an Iceberg Table to have been previously created out-of-band,
+     * otherwise initialization will fail. Users should prefer to create tables
+     * out-of-band so they can be versioned alongside their schemas.
+     */
     @Override
     public void init(Context context) {
         Configuration hadoopConfig = context.getServiceLocator().service(Configuration.class);
@@ -167,10 +135,10 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
         Catalog catalog = context.getServiceLocator().service(Catalog.class);
         // TODO: Get namespace and name from config.
         TableIdentifier id = TableIdentifier.of(tableIdentifierNames);
-        Table table = catalog.tableExists(id) ? catalog.loadTable(id) : catalog.createTable(id, writerSchema);
+        Table table = catalog.loadTable(id);
         WorkerInfo workerInfo = context.getWorkerInfo();
 
-        IcebergWriter writer = newIcebergWriter(config, metrics, workerInfo, table, writerSchema);
+        IcebergWriter writer = newIcebergWriter(config, metrics, workerInfo, table);
         transformer = new Transformer(config, writer);
         try {
             writer.open();

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriter.java
@@ -34,19 +34,17 @@ import org.apache.iceberg.data.Record;
  */
 public class PartitionedIcebergWriter extends BaseIcebergWriter {
 
-    private final Schema writerSchema;
+    private final Schema schema;
     private final PartitionSpec spec;
 
     public PartitionedIcebergWriter(
             WriterMetrics metrics,
             WriterConfig config,
             WorkerInfo workerInfo,
-            Table table,
-            Schema writerSchema,
-            PartitionSpec spec) {
-        super(metrics, config, workerInfo, table, spec);
-        this.writerSchema = writerSchema;
-        this.spec = spec;
+            Table table) {
+        super(metrics, config, workerInfo, table);
+        this.schema = table.schema();
+        this.spec = table.spec();
     }
 
     /**

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/UnpartitionedIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/UnpartitionedIcebergWriter.java
@@ -19,7 +19,6 @@ package io.mantisrx.connector.iceberg.sink.writer;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
 import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.WorkerInfo;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.Record;
 
@@ -36,9 +35,8 @@ public class UnpartitionedIcebergWriter extends BaseIcebergWriter {
             WriterMetrics metrics,
             WriterConfig config,
             WorkerInfo workerInfo,
-            Table table,
-            PartitionSpec spec) {
-        super(metrics, config, workerInfo, table, spec);
+            Table table) {
+        super(metrics, config, workerInfo, table);
     }
 
     /**

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
@@ -29,8 +29,6 @@ public class WriterConfig {
     private final int writerRowGroupSize;
     private final long writerFlushFrequencyBytes;
     private final String writerFileFormat;
-    private final String writerPartitionKey;
-    private final PartitionTransforms writerPartitionKeyTransform;
     private final Configuration hadoopConfig;
 
     /**
@@ -44,10 +42,6 @@ public class WriterConfig {
                 WRITER_FLUSH_FREQUENCY_BYTES, WRITER_FLUSH_FREQUENCY_BYTES_DEFAULT));
         this.writerFileFormat = (String) parameters.get(
                 WRITER_FILE_FORMAT, WRITER_FILE_FORMAT_DEFAULT);
-        this.writerPartitionKey = (String) parameters.get(
-                WRITER_PARTITION_KEY, WRITER_PARTITION_KEY_DEFAULT);
-        this.writerPartitionKeyTransform = (PartitionTransforms) parameters.get(
-                WRITER_PARTITION_KEY_TRANSFORM, WRITER_PARTITION_KEY_TRANSFORM_DEFAULT);
         this.hadoopConfig = hadoopConfig;
     }
 
@@ -73,23 +67,9 @@ public class WriterConfig {
     }
 
     /**
-     * Returns the Iceberg Partition key for writers to use.
-     */
-    public String getWriterPartitionKey() {
-        return writerPartitionKey;
-    }
-
-    /**
      * Returns a Hadoop configuration which has metadata for how and where to write files.
      */
     public Configuration getHadoopConfig() {
         return hadoopConfig;
-    }
-
-    /**
-     * Returns a String representing the type of Transform to apply to a partition key.
-     */
-    public PartitionTransforms getWriterPartitionKeyTransform() {
-        return writerPartitionKeyTransform;
     }
 }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
@@ -57,34 +57,4 @@ public class WriterProperties {
     public static final String WRITER_FILE_FORMAT_DESCRIPTION =
             String.format("File format for writing data files to backing Iceberg store (default: %s)",
                     WRITER_FILE_FORMAT_DEFAULT);
-
-    /**
-     * Partition key for Iceberg partition path.
-     */
-    public static final String WRITER_PARTITION_KEY = "writerPartitionKey";
-    // TODO: Change to long.
-    public static final String WRITER_PARTITION_KEY_DEFAULT = "";
-    public static final String WRITER_PARTITION_KEY_DESCRIPTION =
-            "Partition key for Iceberg partition path (default: none)";
-
-    /**
-     * Type of Transform to apply using partition key field.
-     *
-     * From Iceberg: {@code identity, year, month, day, hour}.
-     * TODO: Support bucket[N] and truncate[W].
-     */
-    public static final String WRITER_PARTITION_KEY_TRANSFORM = "writerPartitionKeyTransform";
-    public static final Enum<PartitionTransforms> WRITER_PARTITION_KEY_TRANSFORM_DEFAULT = PartitionTransforms.NONE;
-    public static final String WRITER_PARTITION_KEY_TRANSFORM_DESCRIPTION =
-            "Type of Transform to apply using partition key field. Available transforms: " +
-            "identity, year, month, day, hour (default: none)";
-
-    public enum PartitionTransforms {
-        IDENTITY,
-        YEAR,
-        MONTH,
-        DAY,
-        HOUR,
-        NONE,
-    }
 }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/codecs/IcebergCodecsTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/codecs/IcebergCodecsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.connector.iceberg.sink.codecs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+
+import io.mantisrx.common.codec.Codec;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IcebergCodecsTest {
+
+    private Codec<DataFile> codec;
+    private DataFile dataFile;
+
+    @BeforeEach
+    void setUp() {
+        codec = IcebergCodecs.dataFile();
+        PartitionSpec spec = PartitionSpec.unpartitioned();
+        dataFile = DataFiles.builder(spec)
+                .withPath("/path/filename.parquet")
+                .withFileSizeInBytes(1)
+                .withPartition(null)
+                .withMetrics(mock(Metrics.class))
+                .withSplitOffsets(Collections.singletonList(1L))
+                .build();
+    }
+
+    @Test
+    void shouldEncodeAndDecodeDataFile() {
+        byte[] encoded = codec.encode(dataFile);
+        DataFile actual = codec.decode(encoded);
+        assertEquals(dataFile.path(), actual.path());
+        assertEquals(dataFile.fileSizeInBytes(), actual.fileSizeInBytes());
+        assertEquals(dataFile.partition(), actual.partition());
+        assertEquals(dataFile.splitOffsets(), actual.splitOffsets());
+    }
+}

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -16,14 +16,26 @@
 
 package io.mantisrx.connector.iceberg.sink.committer;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
+import io.mantisrx.runtime.Context;
+import io.mantisrx.runtime.lifecycle.ServiceLocator;
 import io.mantisrx.runtime.parameter.Parameters;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +48,8 @@ import rx.schedulers.TestScheduler;
 class IcebergCommitterStageTest {
 
     private CommitterConfig config;
+    private Catalog catalog;
+    private Context context;
     private IcebergCommitter committer;
     private TestScheduler scheduler;
     private IcebergCommitterStage.Transformer transformer;
@@ -45,6 +59,17 @@ class IcebergCommitterStageTest {
         this.config = new CommitterConfig(new Parameters());
         this.committer = mock(IcebergCommitter.class);
         this.scheduler = new TestScheduler();
+
+        ServiceLocator serviceLocator = mock(ServiceLocator.class);
+        when(serviceLocator.service(Configuration.class)).thenReturn(mock(Configuration.class));
+        this.catalog = mock(Catalog.class);
+        Table table = mock(Table.class);
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+        when(this.catalog.loadTable(any())).thenReturn(table);
+        when(serviceLocator.service(Catalog.class)).thenReturn(this.catalog);
+        this.context = mock(Context.class);
+        when(this.context.getParameters()).thenReturn(new Parameters());
+        when(this.context.getServiceLocator()).thenReturn(serviceLocator);
     }
 
     @AfterEach
@@ -73,5 +98,20 @@ class IcebergCommitterStageTest {
                 .expectNoEvent(Duration.ofMinutes(4))
                 .thenCancel()
                 .verify();
+
+        verify(committer, times(2)).commit(any());
+    }
+
+    @Test
+    void shouldInitializeWithExistingTable() {
+        IcebergCommitterStage stage = new IcebergCommitterStage("catalog", "database", "table");
+        assertDoesNotThrow(() -> stage.init(context));
+    }
+
+    @Test
+    void shouldFailToInitializeWithMissingTable() {
+        when(catalog.loadTable(any())).thenThrow(new RuntimeException());
+        IcebergCommitterStage stage = new IcebergCommitterStage("catalog", "database", "missing");
+        assertThrows(RuntimeException.class, () -> stage.init(context));
     }
 }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -38,11 +38,13 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.data.Record;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+import reactor.test.scheduler.VirtualTimeScheduler;
 import rx.RxReactiveStreams;
 
 class IcebergWriterStageTest {
@@ -70,6 +72,11 @@ class IcebergWriterStageTest {
         this.context = mock(Context.class);
         when(this.context.getParameters()).thenReturn(new Parameters());
         when(this.context.getServiceLocator()).thenReturn(serviceLocator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        VirtualTimeScheduler.reset();
     }
 
     @Test

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -16,19 +16,31 @@
 
 package io.mantisrx.connector.iceberg.sink.writer;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.time.Duration;
 
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
+import io.mantisrx.runtime.Context;
+import io.mantisrx.runtime.lifecycle.ServiceLocator;
 import io.mantisrx.runtime.parameter.Parameters;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.data.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 import rx.RxReactiveStreams;
@@ -36,18 +48,32 @@ import rx.RxReactiveStreams;
 class IcebergWriterStageTest {
 
     private IcebergWriterStage.Transformer transformer;
+    private Catalog catalog;
+    private Context context;
+    private IcebergWriter writer;
 
     @BeforeEach
     void setUp() throws IOException {
         WriterConfig config = new WriterConfig(new Parameters(), mock(Configuration.class));
-        IcebergWriter writer = mock(IcebergWriter.class);
-        when(writer.close()).thenReturn(mock(DataFile.class));
-        when(writer.length()).thenReturn(Long.MAX_VALUE);
-        this.transformer = new IcebergWriterStage.Transformer(config, writer);
+        this.writer = mock(IcebergWriter.class);
+        when(this.writer.close()).thenReturn(mock(DataFile.class));
+        when(this.writer.length()).thenReturn(Long.MAX_VALUE);
+        this.transformer = new IcebergWriterStage.Transformer(config, this.writer);
+
+        ServiceLocator serviceLocator = mock(ServiceLocator.class);
+        when(serviceLocator.service(Configuration.class)).thenReturn(mock(Configuration.class));
+        this.catalog = mock(Catalog.class);
+        Table table = mock(Table.class);
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+        when(this.catalog.loadTable(any())).thenReturn(table);
+        when(serviceLocator.service(Catalog.class)).thenReturn(this.catalog);
+        this.context = mock(Context.class);
+        when(this.context.getParameters()).thenReturn(new Parameters());
+        when(this.context.getServiceLocator()).thenReturn(serviceLocator);
     }
 
     @Test
-    void shouldCloseOnRowGroupSizeThreshold() {
+    void shouldCloseOnRowGroupSizeThreshold() throws IOException {
         StepVerifier
                 .withVirtualTime(() -> {
                     Flux<Record> upstream = Flux.interval(Duration.ofSeconds(1)).map(i -> mock(Record.class));
@@ -62,5 +88,65 @@ class IcebergWriterStageTest {
                 .expectNoEvent(Duration.ofSeconds(1))
                 .thenCancel()
                 .verify();
+
+        verify(writer, times(3)).open();
+        verify(writer, times(2)).close();
+    }
+
+    @Test
+    void shouldOpenWriterOnSubscribe() throws IOException {
+        Flux<Record> upstream = Flux.just(mock(Record.class));
+        Publisher<DataFile> flow =
+                RxReactiveStreams.toPublisher(RxReactiveStreams.toObservable(upstream).compose(transformer));
+        StepVerifier.create(flow)
+                .expectSubscription()
+                .verifyComplete();
+
+        verify(writer).open();
+    }
+
+    @Test
+    void shouldNoOpCloseWhenFailedToOpen() throws IOException {
+        when(writer.isClosed()).thenReturn(true);
+        doThrow(new IOException()).when(writer).open();
+        Flux<Record> upstream = Flux.just(mock(Record.class));
+        Publisher<DataFile> flow =
+                RxReactiveStreams.toPublisher(RxReactiveStreams.toObservable(upstream).compose(transformer));
+        StepVerifier.create(flow)
+                .expectSubscription()
+                .verifyError();
+
+        verify(writer).open();
+        verify(writer).isClosed();
+        verify(writer, times(0)).close();
+    }
+
+    @Test
+    void shouldCloseOnTerminate() throws IOException {
+        doThrow(new RuntimeException()).when(writer).write(any());
+        Flux<Record> upstream = Flux.just(mock(Record.class));
+        Publisher<DataFile> flow =
+                RxReactiveStreams.toPublisher(RxReactiveStreams.toObservable(upstream).compose(transformer));
+        StepVerifier.create(flow)
+                .expectSubscription()
+                .verifyComplete();
+
+        verify(writer).open();
+        verify(writer).write(any());
+        verify(writer).isClosed();
+        verify(writer, times(1)).close();
+    }
+
+    @Test
+    void shouldInitializeWithExistingTable() {
+        IcebergWriterStage stage = new IcebergWriterStage("catalog", "database", "table");
+        assertDoesNotThrow(() -> stage.init(context));
+    }
+
+    @Test
+    void shouldFailToInitializeWithMissingTable() {
+        when(catalog.loadTable(any())).thenThrow(new RuntimeException());
+        IcebergWriterStage stage = new IcebergWriterStage("catalog", "database", "missing");
+        assertThrows(RuntimeException.class, () -> stage.init(context));
     }
 }


### PR DESCRIPTION
### Context

This PR primarily removes auto-create tables. See commit comment from https://github.com/Netflix/mantis-connectors/pull/14/commits/e136fb6c02a6d85bc34a5f7b743104bf26cc0658 for details. This PR also lazily initializes (opens a file appender) the writer on subscribe, rather than on stage init.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
