### PR TITLE
Refactor writer. Refactor tests.

### DIFF
--- a/mantis-connector-iceberg/build.gradle
+++ b/mantis-connector-iceberg/build.gradle
@@ -39,9 +39,6 @@ dependencies {
 
     testImplementation "org.apache.hadoop:hadoop-common:$hadoopVersion"
     testImplementation "org.apache.iceberg:iceberg-data:$icebergVersion"
-    testImplementation "io.projectreactor:reactor-core:$reactorVersion"
-    testImplementation "io.projectreactor:reactor-test:$reactorVersion"
-    testImplementation "io.reactivex:rxjava-reactive-streams:$rxAdapterVersion"
     testImplementation "org.slf4j:slf4j-log4j12:$slf4jVersion"
 }
 

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
@@ -137,8 +137,6 @@ public abstract class BaseIcebergWriter implements IcebergWriter {
                 .withSplitOffsets(appender.splitOffsets())
                 .build();
 
-        logger.info("writing DataFile: {}", dataFile);
-
         appender = null;
         file = null;
 


### PR DESCRIPTION
### Context

This PR fixes an issue in writers where a failure on opening a file will prevent a perfectly-fine `DataFile` from being emitted downstream. This also catches errors and exceptions gracefully for the writer and committer so the flow is not broken.

This also PR removes the use of reactor in tests in favor of standard rx test schedulers and subscribers and refactors said tests.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
