### PR TITLE
Add writer and committer metrics

### DIFF
--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitter.java
@@ -20,13 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
-import io.mantisrx.connector.iceberg.sink.committer.metrics.CommitterMetrics;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -36,18 +32,9 @@ import org.slf4j.LoggerFactory;
  */
 public class IcebergCommitter {
 
-    private static final Logger logger = LoggerFactory.getLogger(IcebergCommitter.class);
-
-    private final CommitterMetrics metrics;
-    private final CommitterConfig config;
     private final Table table;
 
-    public IcebergCommitter(
-            CommitterMetrics metrics,
-            CommitterConfig config,
-            Table table) {
-        this.metrics = metrics;
-        this.config = config;
+    public IcebergCommitter(Table table) {
         this.table = table;
     }
 
@@ -60,9 +47,6 @@ public class IcebergCommitter {
         AppendFiles tableAppender = table.newAppend();
         dataFiles.forEach(tableAppender::appendFile);
         tableAppender.commit();
-        Map<String, Object> summary =
-                table.currentSnapshot() == null ? new HashMap<>() : new HashMap<>(table.currentSnapshot().summary());
-        logger.info("committed {}", summary);
-        return summary;
+        return table.currentSnapshot() == null ? new HashMap<>() : new HashMap<>(table.currentSnapshot().summary());
     }
 }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStage.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStage.java
@@ -49,7 +49,6 @@ public class IcebergCommitterStage implements ScalarComputation<DataFile, Map<St
 
     private static final Logger logger = LoggerFactory.getLogger(IcebergCommitterStage.class);
 
-    private final CommitterMetrics metrics;
     private final String[] tableIdentifierNames;
 
     private Transformer transformer;
@@ -78,7 +77,6 @@ public class IcebergCommitterStage implements ScalarComputation<DataFile, Map<St
     }
 
     public IcebergCommitterStage(String... tableIdentifierNames) {
-        this.metrics = new CommitterMetrics();
         this.tableIdentifierNames = tableIdentifierNames;
     }
 
@@ -95,12 +93,13 @@ public class IcebergCommitterStage implements ScalarComputation<DataFile, Map<St
     @Override
     public void init(Context context) {
         CommitterConfig config = new CommitterConfig(context.getParameters());
+        CommitterMetrics metrics = new CommitterMetrics();
         Catalog catalog = context.getServiceLocator().service(Catalog.class);
         // TODO: Get namespace and name from config.
         TableIdentifier id = TableIdentifier.of(tableIdentifierNames);
         Table table = catalog.loadTable(id);
-        IcebergCommitter committer = new IcebergCommitter(metrics, config, table);
-        transformer = new Transformer(config, committer, Schedulers.computation());
+        IcebergCommitter committer = new IcebergCommitter(table);
+        transformer = new Transformer(config, metrics, committer, Schedulers.computation());
     }
 
     @Override
@@ -119,35 +118,47 @@ public class IcebergCommitterStage implements ScalarComputation<DataFile, Map<St
     public static class Transformer implements Observable.Transformer<DataFile, Map<String, Object>> {
 
         private final CommitterConfig config;
+        private final CommitterMetrics metrics;
         private final IcebergCommitter committer;
         private final Scheduler scheduler;
 
-        public Transformer(CommitterConfig config, IcebergCommitter committer, Scheduler scheduler) {
+        public Transformer(CommitterConfig config,
+                           CommitterMetrics metrics,
+                           IcebergCommitter committer,
+                           Scheduler scheduler) {
             this.config = config;
+            this.metrics = metrics;
             this.committer = committer;
             this.scheduler = scheduler;
         }
 
         /**
-         * Periodically commits DataFiles in a batch.
+         * Periodically commits DataFiles to Iceberg as a batch.
          */
         @Override
         public Observable<Map<String, Object>> call(Observable<DataFile> source) {
             return source
                     .buffer(config.getCommitFrequencyMs(), TimeUnit.MILLISECONDS, scheduler)
+                    .doOnNext(dataFiles -> metrics.increment(CommitterMetrics.INVOCATION_COUNT))
                     .filter(dataFiles -> !dataFiles.isEmpty())
                     .map(dataFiles -> {
                         try {
-                            return committer.commit(dataFiles);
+                            long start = scheduler.now();
+                            Map<String, Object> summary = committer.commit(dataFiles);
+                            long now = scheduler.now();
+                            metrics.setGauge(CommitterMetrics.COMMIT_LATENCY_MSEC, now - start);
+                            metrics.setGauge(CommitterMetrics.COMMIT_BATCH_SIZE, dataFiles.size());
+                            return summary;
                         } catch (RuntimeException e) {
-                            // metric
+                            metrics.increment(CommitterMetrics.COMMIT_FAILURE_COUNT);
                             logger.error("error committing to Iceberg", e);
                             return new HashMap<String, Object>();
                         }
                     })
                     .filter(summary -> !summary.isEmpty())
                     .doOnNext(summary -> {
-                        // metric
+                        metrics.increment(CommitterMetrics.COMMIT_SUCCESS_COUNT);
+                        logger.info("committed {}", summary);
                     });
         }
     }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/metrics/CommitterMetrics.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/metrics/CommitterMetrics.java
@@ -16,17 +16,92 @@
 
 package io.mantisrx.connector.iceberg.sink.committer.metrics;
 
+import io.mantisrx.common.metrics.Counter;
+import io.mantisrx.common.metrics.Gauge;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
 
 public class CommitterMetrics {
+
+    public static final String INVOCATION_COUNT = "invocationCount";
+    private final Counter invocationCount;
+
+    public static final String COMMIT_SUCCESS_COUNT = "commitSuccessCount";
+    private final Counter commitSuccessCount;
+
+    public static final String COMMIT_FAILURE_COUNT = "commitFailureCount";
+    private final Counter commitFailureCount;
+
+    public static final String COMMIT_LATENCY_MSEC = "commitLatencyMsec";
+    private final Gauge commitLatencyMsec;
+
+    public static final String COMMIT_BATCH_SIZE = "commitBatchSize";
+    private final Gauge commitBatchSize;
+
     public CommitterMetrics() {
         Metrics metrics = new Metrics.Builder()
                 .name(CommitterMetrics.class.getCanonicalName())
-                // TODO: Add metrics
+                .addCounter(INVOCATION_COUNT)
+                .addCounter(COMMIT_SUCCESS_COUNT)
+                .addCounter(COMMIT_FAILURE_COUNT)
+                .addCounter(COMMIT_LATENCY_MSEC)
+                .addCounter(COMMIT_BATCH_SIZE)
                 .build();
+
         metrics = MetricsRegistry.getInstance().registerAndGet(metrics);
 
-        // TODO: Get metrics, e.g., getCounter(name).
+        invocationCount = metrics.getCounter(INVOCATION_COUNT);
+        commitSuccessCount = metrics.getCounter(COMMIT_SUCCESS_COUNT);
+        commitFailureCount = metrics.getCounter(COMMIT_FAILURE_COUNT);
+        commitLatencyMsec = metrics.getGauge(COMMIT_LATENCY_MSEC);
+        commitBatchSize = metrics.getGauge(COMMIT_BATCH_SIZE);
+    }
+
+    public void setGauge(final String metric, final long value) {
+        switch (metric) {
+            case COMMIT_LATENCY_MSEC:
+                commitLatencyMsec.set(value);
+                break;
+            case COMMIT_BATCH_SIZE:
+                commitBatchSize.set(value);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void increment(final String metric) {
+        switch (metric) {
+            case INVOCATION_COUNT:
+                invocationCount.increment();
+                break;
+            case COMMIT_SUCCESS_COUNT:
+                commitSuccessCount.increment();
+                break;
+            case COMMIT_FAILURE_COUNT:
+                commitFailureCount.increment();
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void increment(final String metric, final long value) {
+        switch (metric) {
+            case INVOCATION_COUNT:
+                invocationCount.increment(value);
+                break;
+            case COMMIT_SUCCESS_COUNT:
+                commitSuccessCount.increment(value);
+                break;
+            case COMMIT_FAILURE_COUNT:
+                commitFailureCount.increment(value);
+                break;
+            case COMMIT_BATCH_SIZE:
+                commitBatchSize.increment(value);
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/metrics/CommitterMetrics.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/metrics/CommitterMetrics.java
@@ -44,8 +44,8 @@ public class CommitterMetrics {
                 .addCounter(INVOCATION_COUNT)
                 .addCounter(COMMIT_SUCCESS_COUNT)
                 .addCounter(COMMIT_FAILURE_COUNT)
-                .addCounter(COMMIT_LATENCY_MSEC)
-                .addCounter(COMMIT_BATCH_SIZE)
+                .addGauge(COMMIT_LATENCY_MSEC)
+                .addGauge(COMMIT_BATCH_SIZE)
                 .build();
 
         metrics = MetricsRegistry.getInstance().registerAndGet(metrics);

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.UUID;
 
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
-import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.WorkerInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
@@ -52,7 +51,6 @@ public abstract class BaseIcebergWriter implements IcebergWriter {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseIcebergWriter.class);
 
-    private final WriterMetrics metrics;
     private final WriterConfig config;
     private final WorkerInfo workerInfo;
 
@@ -65,12 +63,7 @@ public abstract class BaseIcebergWriter implements IcebergWriter {
     private OutputFile file;
     private StructLike key;
 
-    public BaseIcebergWriter(
-            WriterMetrics metrics,
-            WriterConfig config,
-            WorkerInfo workerInfo,
-            Table table) {
-        this.metrics = metrics;
+    public BaseIcebergWriter(WriterConfig config, WorkerInfo workerInfo, Table table) {
         this.config = config;
 
         this.table = table;

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriter.java
@@ -17,7 +17,6 @@
 package io.mantisrx.connector.iceberg.sink.writer;
 
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
-import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.WorkerInfo;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -37,12 +36,8 @@ public class PartitionedIcebergWriter extends BaseIcebergWriter {
     private final Schema schema;
     private final PartitionSpec spec;
 
-    public PartitionedIcebergWriter(
-            WriterMetrics metrics,
-            WriterConfig config,
-            WorkerInfo workerInfo,
-            Table table) {
-        super(metrics, config, workerInfo, table);
+    public PartitionedIcebergWriter(WriterConfig config, WorkerInfo workerInfo, Table table) {
+        super(config, workerInfo, table);
         this.schema = table.schema();
         this.spec = table.spec();
     }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/UnpartitionedIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/UnpartitionedIcebergWriter.java
@@ -17,7 +17,6 @@
 package io.mantisrx.connector.iceberg.sink.writer;
 
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
-import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.WorkerInfo;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.Record;
@@ -31,12 +30,8 @@ import org.apache.iceberg.data.Record;
  */
 public class UnpartitionedIcebergWriter extends BaseIcebergWriter {
 
-    public UnpartitionedIcebergWriter(
-            WriterMetrics metrics,
-            WriterConfig config,
-            WorkerInfo workerInfo,
-            Table table) {
-        super(metrics, config, workerInfo, table);
+    public UnpartitionedIcebergWriter(WriterConfig config, WorkerInfo workerInfo, Table table) {
+        super(config, workerInfo, table);
     }
 
     /**

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/metrics/WriterMetrics.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/metrics/WriterMetrics.java
@@ -16,17 +16,122 @@
 
 package io.mantisrx.connector.iceberg.sink.writer.metrics;
 
+import io.mantisrx.common.metrics.Counter;
+import io.mantisrx.common.metrics.Gauge;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
 
 public class WriterMetrics {
+
+    public static final String OPEN_SUCCESS_COUNT = "openSuccessCount";
+    private final Counter openSuccessCount;
+
+    public static final String OPEN_FAILURE_COUNT = "openFailureCount";
+    private final Counter openFailureCount;
+
+    public static final String WRITE_SUCCESS_COUNT = "writeSuccessCount";
+    private final Counter writeSuccessCount;
+
+    public static final String WRITE_FAILURE_COUNT = "writeFailureCount";
+    private final Counter writeFailureCount;
+
+    public static final String BATCH_SUCCESS_COUNT = "batchSuccessCount";
+    private final Counter batchSuccessCount;
+
+    public static final String BATCH_FAILURE_COUNT = "batchFailureCount";
+    private final Counter batchFailureCount;
+
+    public static final String BATCH_SIZE = "batchSize";
+    private final Gauge batchSize;
+
+    public static final String BATCH_SIZE_BYTES = "batchSizeBytes";
+    private final Gauge batchSizeBytes;
+
     public WriterMetrics() {
         Metrics metrics = new Metrics.Builder()
                 .name(WriterMetrics.class.getCanonicalName())
-                // TODO: Add metrics
+                .addCounter(OPEN_SUCCESS_COUNT)
+                .addCounter(OPEN_FAILURE_COUNT)
+                .addCounter(WRITE_SUCCESS_COUNT)
+                .addCounter(WRITE_FAILURE_COUNT)
+                .addCounter(BATCH_SUCCESS_COUNT)
+                .addCounter(BATCH_FAILURE_COUNT)
+                .addGauge(BATCH_SIZE)
+                .addGauge(BATCH_SIZE_BYTES)
                 .build();
+
         metrics = MetricsRegistry.getInstance().registerAndGet(metrics);
 
-        // TODO: Get metrics, e.g., getCounter(name).
+        openSuccessCount = metrics.getCounter(OPEN_SUCCESS_COUNT);
+        openFailureCount = metrics.getCounter(OPEN_FAILURE_COUNT);
+        writeSuccessCount = metrics.getCounter(WRITE_SUCCESS_COUNT);
+        writeFailureCount = metrics.getCounter(WRITE_FAILURE_COUNT);
+        batchSuccessCount = metrics.getCounter(BATCH_SUCCESS_COUNT);
+        batchFailureCount = metrics.getCounter(BATCH_FAILURE_COUNT);
+        batchSize = metrics.getGauge(BATCH_SIZE);
+        batchSizeBytes = metrics.getGauge(BATCH_SIZE_BYTES);
+    }
+
+    public void setGauge(final String metric, final long value) {
+        switch (metric) {
+            case BATCH_SIZE:
+                batchSize.set(value);
+                break;
+            case BATCH_SIZE_BYTES:
+                batchSizeBytes.set(value);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void increment(final String metric) {
+        switch (metric) {
+            case OPEN_SUCCESS_COUNT:
+                openSuccessCount.increment();
+                break;
+            case OPEN_FAILURE_COUNT:
+                openFailureCount.increment();
+                break;
+            case WRITE_SUCCESS_COUNT:
+                writeSuccessCount.increment();
+                break;
+            case WRITE_FAILURE_COUNT:
+                writeFailureCount.increment();
+                break;
+            case BATCH_SUCCESS_COUNT:
+                batchSuccessCount.increment();
+                break;
+            case BATCH_FAILURE_COUNT:
+                batchFailureCount.increment();
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void increment(final String metric, final long value) {
+        switch (metric) {
+            case OPEN_SUCCESS_COUNT:
+                openSuccessCount.increment(value);
+                break;
+            case OPEN_FAILURE_COUNT:
+                openFailureCount.increment(value);
+                break;
+            case WRITE_SUCCESS_COUNT:
+                writeSuccessCount.increment(value);
+                break;
+            case WRITE_FAILURE_COUNT:
+                writeFailureCount.increment(value);
+                break;
+            case BATCH_SUCCESS_COUNT:
+                batchSuccessCount.increment(value);
+                break;
+            case BATCH_FAILURE_COUNT:
+                batchFailureCount.increment(value);
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -62,7 +62,7 @@ class IcebergCommitterStageTest {
         this.subscriber = new TestSubscriber<>();
 
         this.config = new CommitterConfig(new Parameters());
-        this.metrics = mock(CommitterMetrics.class);
+        this.metrics = new CommitterMetrics();
         this.committer = mock(IcebergCommitter.class);
 
         transformer = new IcebergCommitterStage.Transformer(config, metrics, committer, scheduler);

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
+import io.mantisrx.connector.iceberg.sink.committer.metrics.CommitterMetrics;
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.lifecycle.ServiceLocator;
 import io.mantisrx.runtime.parameter.Parameters;
@@ -49,6 +50,7 @@ class IcebergCommitterStageTest {
     private TestScheduler scheduler;
     private TestSubscriber<Map<String, Object>> subscriber;
     private CommitterConfig config;
+    private CommitterMetrics metrics;
     private Catalog catalog;
     private Context context;
     private IcebergCommitter committer;
@@ -60,9 +62,10 @@ class IcebergCommitterStageTest {
         this.subscriber = new TestSubscriber<>();
 
         this.config = new CommitterConfig(new Parameters());
+        this.metrics = mock(CommitterMetrics.class);
         this.committer = mock(IcebergCommitter.class);
 
-        transformer = new IcebergCommitterStage.Transformer(config, committer, scheduler);
+        transformer = new IcebergCommitterStage.Transformer(config, metrics, committer, scheduler);
 
         ServiceLocator serviceLocator = mock(ServiceLocator.class);
         when(serviceLocator.service(Configuration.class)).thenReturn(mock(Configuration.class));

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
+import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.lifecycle.ServiceLocator;
 import io.mantisrx.runtime.parameter.Parameters;
@@ -60,10 +61,11 @@ class IcebergWriterStageTest {
         this.subscriber = new TestSubscriber<>();
 
         WriterConfig config = new WriterConfig(new Parameters(), mock(Configuration.class));
+        WriterMetrics metrics = new WriterMetrics();
         this.writer = mock(IcebergWriter.class);
         when(this.writer.close()).thenReturn(mock(DataFile.class));
         when(this.writer.length()).thenReturn(Long.MAX_VALUE);
-        this.transformer = new IcebergWriterStage.Transformer(config, this.writer);
+        this.transformer = new IcebergWriterStage.Transformer(config, metrics, this.writer);
 
         ServiceLocator serviceLocator = mock(ServiceLocator.class);
         when(serviceLocator.service(Configuration.class)).thenReturn(mock(Configuration.class));


### PR DESCRIPTION
### Context

This PR adds writer and committer metrics. Metrics are added to each class's `Transformer` instead of the Stages. That way, users are still free to use a `Transformer` standalone, independently of the Stages (although using the Stages is still recommended).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
