### PR TITLE
Move table identifier config to params.

### DIFF
--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/config/CommitterConfig.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/config/CommitterConfig.java
@@ -19,14 +19,13 @@ package io.mantisrx.connector.iceberg.sink.committer.config;
 import static io.mantisrx.connector.iceberg.sink.committer.config.CommitterProperties.COMMIT_FREQUENCY_MS;
 import static io.mantisrx.connector.iceberg.sink.committer.config.CommitterProperties.COMMIT_FREQUENCY_MS_DEFAULT;
 
+import io.mantisrx.connector.iceberg.sink.config.SinkConfig;
 import io.mantisrx.runtime.parameter.Parameters;
 
 /**
  * Config for controlling Iceberg Committer semantics.
- *
- * TODO: Add Iceberg Table properties.
  */
-public class CommitterConfig {
+public class CommitterConfig extends SinkConfig {
 
     private final long commitFrequencyMs;
 
@@ -34,7 +33,9 @@ public class CommitterConfig {
      * Creates an instance from {@link Parameters} derived from the current Mantis Stage's {@code Context}.
      */
     public CommitterConfig(Parameters parameters) {
-        this.commitFrequencyMs = Long.parseLong((String) parameters.get(COMMIT_FREQUENCY_MS, COMMIT_FREQUENCY_MS_DEFAULT));
+        super(parameters);
+        this.commitFrequencyMs =
+                Long.parseLong((String) parameters.get(COMMIT_FREQUENCY_MS, COMMIT_FREQUENCY_MS_DEFAULT));
     }
 
     /**

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/config/SinkConfig.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/config/SinkConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.connector.iceberg.sink.config;
+
+
+import static io.mantisrx.connector.iceberg.sink.config.SinkProperties.SINK_CATALOG;
+import static io.mantisrx.connector.iceberg.sink.config.SinkProperties.SINK_DATABASE;
+import static io.mantisrx.connector.iceberg.sink.config.SinkProperties.SINK_TABLE;
+
+import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
+import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
+import io.mantisrx.runtime.parameter.Parameters;
+
+/**
+ * Convenient base config used by {@link WriterConfig} and {@link CommitterConfig}.
+ */
+public class SinkConfig {
+
+    private final String catalog;
+    private final String database;
+    private final String table;
+
+    /**
+     * Creates an instance from {@link Parameters} derived from the current Mantis Stage's {@code Context}.
+     */
+    public SinkConfig(Parameters parameters) {
+        this.catalog = (String) parameters.get(SINK_CATALOG);
+        this.database = (String) parameters.get(SINK_DATABASE);
+        this.table = (String) parameters.get(SINK_TABLE);
+    }
+
+    /**
+     * Returns a String for Iceberg Catalog name.
+     */
+    public String getCatalog() {
+        return catalog;
+    }
+
+    /**
+     * Returns a String for the database name in a catalog.
+     */
+    public String getDatabase() {
+        return database;
+    }
+
+    /**
+     * Returns a String for the table within a database.
+     */
+    public String getTable() {
+        return table;
+    }
+}

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/config/SinkProperties.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/config/SinkProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.connector.iceberg.sink.config;
+
+/**
+ * Property key names and default values for the base Iceberg Sink config.
+ */
+public class SinkProperties {
+
+    private SinkProperties() {
+    }
+
+    /**
+     * Name of Iceberg Catalog.
+     */
+    public static final String SINK_CATALOG = "sinkCatalog";
+    public static final String SINK_CATALOG_DESCRIPTION = "Name of Iceberg Catalog";
+
+    /**
+     * Name of database within Iceberg Catalog.
+     */
+    public static final String SINK_DATABASE = "sinkDatabase";
+    public static final String SINK_DATABASE_DESCRIPTION = "Name of database within Iceberg Catalog";
+
+    /**
+     * Name of table within database.
+     */
+    public static final String SINK_TABLE = "sinkTable";
+    public static final String SINK_TABLE_DESCRIPTION = "Name of table within database";
+}

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
@@ -18,13 +18,14 @@ package io.mantisrx.connector.iceberg.sink.writer.config;
 
 import static io.mantisrx.connector.iceberg.sink.writer.config.WriterProperties.*;
 
+import io.mantisrx.connector.iceberg.sink.config.SinkConfig;
 import io.mantisrx.runtime.parameter.Parameters;
 import org.apache.hadoop.conf.Configuration;
 
 /**
  * Config for controlling Iceberg Writer semantics.
  */
-public class WriterConfig {
+public class WriterConfig extends SinkConfig {
 
     private final int writerRowGroupSize;
     private final long writerFlushFrequencyBytes;
@@ -33,9 +34,9 @@ public class WriterConfig {
 
     /**
      * Creates an instance from {@link Parameters} derived from the current Mantis Stage's {@code Context}.
-     * TODO: Composite keys.
      */
     public WriterConfig(Parameters parameters, Configuration hadoopConfig) {
+        super(parameters);
         this.writerRowGroupSize = (int) parameters.get(
                 WRITER_ROW_GROUP_SIZE, WRITER_ROW_GROUP_SIZE_DEFAULT);
         this.writerFlushFrequencyBytes = Long.parseLong((String) parameters.get(

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
@@ -20,10 +20,6 @@ import org.apache.iceberg.FileFormat;
 
 /**
  * Property key names and default values for an Iceberg Committer.
- *
- * TODO: Add Iceberg table properties (the writer sub-props).
- * TODO: Use Iceberg table properties's row-group-size instead.
- * TODO: Add Hadoop Configuration.
  */
 public class WriterProperties {
 

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/TableIdentifierParameters.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/TableIdentifierParameters.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.connector.iceberg.sink;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import io.mantisrx.connector.iceberg.sink.config.SinkProperties;
+import io.mantisrx.runtime.parameter.Parameters;
+
+public class TableIdentifierParameters {
+
+    private TableIdentifierParameters() {
+    }
+
+    public static Parameters newParameters() {
+        Map<String, Object> state = new HashMap<>();
+        Set<String> required = new HashSet<>();
+
+        required.add(SinkProperties.SINK_CATALOG);
+        state.put(SinkProperties.SINK_CATALOG, "catalog");
+
+        required.add(SinkProperties.SINK_DATABASE);
+        state.put(SinkProperties.SINK_DATABASE, "database");
+
+        required.add(SinkProperties.SINK_TABLE);
+        state.put(SinkProperties.SINK_TABLE, "table");
+
+        return new Parameters(state, required, required);
+    }
+}

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.mantisrx.connector.iceberg.sink.TableIdentifierParameters;
 import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
 import io.mantisrx.connector.iceberg.sink.committer.metrics.CommitterMetrics;
 import io.mantisrx.runtime.Context;
@@ -61,7 +62,8 @@ class IcebergCommitterStageTest {
         this.scheduler = new TestScheduler();
         this.subscriber = new TestSubscriber<>();
 
-        this.config = new CommitterConfig(new Parameters());
+        Parameters parameters = TableIdentifierParameters.newParameters();
+        this.config = new CommitterConfig(parameters);
         this.metrics = new CommitterMetrics();
         this.committer = mock(IcebergCommitter.class);
 
@@ -75,7 +77,7 @@ class IcebergCommitterStageTest {
         when(this.catalog.loadTable(any())).thenReturn(table);
         when(serviceLocator.service(Catalog.class)).thenReturn(this.catalog);
         this.context = mock(Context.class);
-        when(this.context.getParameters()).thenReturn(new Parameters());
+        when(this.context.getParameters()).thenReturn(parameters);
         when(this.context.getServiceLocator()).thenReturn(serviceLocator);
     }
 
@@ -126,14 +128,14 @@ class IcebergCommitterStageTest {
 
     @Test
     void shouldInitializeWithExistingTable() {
-        IcebergCommitterStage stage = new IcebergCommitterStage("catalog", "database", "table");
+        IcebergCommitterStage stage = new IcebergCommitterStage();
         assertDoesNotThrow(() -> stage.init(context));
     }
 
     @Test
     void shouldFailToInitializeWithMissingTable() {
         when(catalog.loadTable(any())).thenThrow(new RuntimeException());
-        IcebergCommitterStage stage = new IcebergCommitterStage("catalog", "database", "missing");
+        IcebergCommitterStage stage = new IcebergCommitterStage();
         assertThrows(RuntimeException.class, () -> stage.init(context));
     }
 }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import io.mantisrx.connector.iceberg.sink.TableIdentifierParameters;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
 import io.mantisrx.connector.iceberg.sink.writer.metrics.WriterMetrics;
 import io.mantisrx.runtime.Context;
@@ -60,7 +61,8 @@ class IcebergWriterStageTest {
         this.scheduler = new TestScheduler();
         this.subscriber = new TestSubscriber<>();
 
-        WriterConfig config = new WriterConfig(new Parameters(), mock(Configuration.class));
+        Parameters parameters = TableIdentifierParameters.newParameters();
+        WriterConfig config = new WriterConfig(parameters, mock(Configuration.class));
         WriterMetrics metrics = new WriterMetrics();
         this.writer = mock(IcebergWriter.class);
         when(this.writer.close()).thenReturn(mock(DataFile.class));
@@ -75,7 +77,7 @@ class IcebergWriterStageTest {
         when(this.catalog.loadTable(any())).thenReturn(table);
         when(serviceLocator.service(Catalog.class)).thenReturn(this.catalog);
         this.context = mock(Context.class);
-        when(this.context.getParameters()).thenReturn(new Parameters());
+        when(this.context.getParameters()).thenReturn(parameters);
         when(this.context.getServiceLocator()).thenReturn(serviceLocator);
 
         Observable<Record> source = Observable.interval(1, TimeUnit.SECONDS, scheduler)
@@ -157,14 +159,14 @@ class IcebergWriterStageTest {
 
     @Test
     void shouldInitializeWithExistingTable() {
-        IcebergWriterStage stage = new IcebergWriterStage("catalog", "database", "table");
+        IcebergWriterStage stage = new IcebergWriterStage();
         assertDoesNotThrow(() -> stage.init(context));
     }
 
     @Test
     void shouldFailToInitializeWithMissingTable() {
         when(catalog.loadTable(any())).thenThrow(new RuntimeException());
-        IcebergWriterStage stage = new IcebergWriterStage("catalog", "database", "missing");
+        IcebergWriterStage stage = new IcebergWriterStage();
         assertThrows(RuntimeException.class, () -> stage.init(context));
     }
 }


### PR DESCRIPTION
### Context

This PR moves Iceberg TableIdentifier-related params to job params, specifically from the stage. Note that these configs are defined in both the writer and committer stages. This is because (1) there's no job for the user to use; only stages or transformers; (2) config is scoped to the job and is a map anyway, so last write (definition) wins.

The benefit of this change is users no longer need to rebuild artifacts to change their catalog/database/table, but instead just put in a param.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
