### PR TITLE
Disable non-deterministic tests

### DIFF
--- a/mantis-connector-publish/src/test/java/io/mantisrx/connector/publish/core/QueryRegistryTest.java
+++ b/mantis-connector-publish/src/test/java/io/mantisrx/connector/publish/core/QueryRegistryTest.java
@@ -116,6 +116,7 @@ class QueryRegistryTest {
 
 
     @Test
+    @Disabled("time-based, non-deterministic")
     void deregisterQueryTest() throws InterruptedException {
         try {
             QueryRegistry queryRegistry = new QueryRegistry.Builder().build();
@@ -155,6 +156,7 @@ class QueryRegistryTest {
     }
 
     @Test
+    @Disabled("time-based, non-deterministic")
     void registerIdenticalQueryGetsDedupedTest() {
         QueryRegistry queryRegistry = new QueryRegistry.Builder().withClientIdPrefix("myPrefix").build();
 
@@ -197,6 +199,7 @@ class QueryRegistryTest {
     }
 
     @Test
+    @Disabled("time-based, non-deterministic")
     void registerIdenticalQueryRemovalTest() throws InterruptedException {
         QueryRegistry queryRegistry = new QueryRegistry.Builder().withClientIdPrefix("myPrefix").build();
 
@@ -251,7 +254,7 @@ class QueryRegistryTest {
     }
 
     @Test
-    @Disabled
+    @Disabled("time-based, non-deterministic")
     void registerQueryMultipleAppsRemovalTest() throws InterruptedException {
         QueryRegistry queryRegistry = new QueryRegistry.Builder().withClientIdPrefix("myPrefix").build();
 


### PR DESCRIPTION
### Context

There are intermittent failures in the build due to non-deterministic, time-based tests. This requires more fundamental refactor to inject clocks, schedulers, etc.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
