### PR TITLE
Catch runtime i/o failure on datafile creation.

### DIFF
--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -200,7 +201,7 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
                             DataFile dataFile = writer.close();
                             counter.reset();
                             return dataFile;
-                        } catch (IOException e) {
+                        } catch (IOException | RuntimeIOException e) {
                             metrics.increment(WriterMetrics.BATCH_FAILURE_COUNT);
                             logger.error("error writing DataFile", e);
                             return ERROR_DATA_FILE;


### PR DESCRIPTION
### Context

For S3-backed systems, there's a case where we try to access the file
but it doesn't exist due to read-after-write consistency on S3. This
will throw a runtime exception which will fail out the observable. This
needs to be fixed in the writer, but in the meantime, let's make sure we
have visibility through metrics and logs.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
