### PR TITLE
Add a time-base semantic to writers to supplement size-based

### DIFF
--- a/mantis-connector-iceberg/build.gradle
+++ b/mantis-connector-iceberg/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     // We only need the Configuration interface. Users can bring their own hadoop-common version.
     shadow "org.apache.hadoop:hadoop-common:$hadoopVersion"
 
-    api "org.apache.iceberg:iceberg-api:$icebergVersion"
-    // Exclude in case there are difference in SHAs in 0.7.0 incubation version. We only use interfaces anyway.
+    // Exclude in case there are differences in SHAs between 0.7.0 incubation versions.
+    shadow "org.apache.iceberg:iceberg-api:$icebergVersion"
     shadow "org.apache.iceberg:iceberg-core:$icebergVersion"
     shadow "org.apache.iceberg:iceberg-data:$icebergVersion"
     shadow "org.apache.iceberg:iceberg-parquet:$icebergVersion"
@@ -36,8 +36,6 @@ dependencies {
 
     // We only need this for local mains(). Users bring their own implementation.
     shadow "org.slf4j:slf4j-log4j12:$slf4jVersion"
-
-    implementation 'io.vavr:vavr:0.10.3'
 
     testImplementation "org.apache.hadoop:hadoop-common:$hadoopVersion"
     testImplementation "org.apache.iceberg:iceberg-data:$icebergVersion"

--- a/mantis-connector-iceberg/build.gradle
+++ b/mantis-connector-iceberg/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     // We only need this for local mains(). Users bring their own implementation.
     shadow "org.slf4j:slf4j-log4j12:$slf4jVersion"
 
+    implementation 'io.vavr:vavr:0.10.3'
+
     testImplementation "org.apache.hadoop:hadoop-common:$hadoopVersion"
     testImplementation "org.apache.iceberg:iceberg-data:$icebergVersion"
     testImplementation "org.slf4j:slf4j-log4j12:$slf4jVersion"

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/BaseIcebergWriter.java
@@ -122,7 +122,8 @@ public abstract class BaseIcebergWriter implements IcebergWriter {
 
         // Calls to FileAppender#close can fail if the backing file system fails to close.
         // For example, this can happen for an S3-backed file system where it might fail
-        // to GET the status of the file.
+        // to GET the status of the file. The file would have already been closed.
+        // Callers should open a new appender.
         try {
             appender.close();
 

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 
 public interface IcebergWriter {
 
@@ -27,7 +28,7 @@ public interface IcebergWriter {
 
     void write(Record record);
 
-    DataFile close() throws IOException;
+    DataFile close() throws IOException, RuntimeIOException;
 
     boolean isClosed();
 

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -267,7 +268,7 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
         }
 
         private boolean isErrorDataFile(DataFile dataFile) {
-            return ERROR_DATA_FILE.path() == dataFile.path() &&
+            return Comparators.charSequences().compare(ERROR_DATA_FILE.path(), dataFile.path()) == 0 &&
                     ERROR_DATA_FILE.fileSizeInBytes() == dataFile.fileSizeInBytes() &&
                     ERROR_DATA_FILE.recordCount() == dataFile.recordCount();
         }

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
@@ -29,6 +29,7 @@ public class WriterConfig extends SinkConfig {
 
     private final int writerRowGroupSize;
     private final long writerFlushFrequencyBytes;
+    private final long writerFlushFrequencyMsec;
     private final String writerFileFormat;
     private final Configuration hadoopConfig;
 
@@ -41,6 +42,8 @@ public class WriterConfig extends SinkConfig {
                 WRITER_ROW_GROUP_SIZE, WRITER_ROW_GROUP_SIZE_DEFAULT);
         this.writerFlushFrequencyBytes = Long.parseLong((String) parameters.get(
                 WRITER_FLUSH_FREQUENCY_BYTES, WRITER_FLUSH_FREQUENCY_BYTES_DEFAULT));
+        this.writerFlushFrequencyMsec = Long.parseLong((String) parameters.get(
+                WRITER_FLUSH_FREQUENCY_MSEC, WRITER_FLUSH_FREQUENCY_MSEC_DEFAULT));
         this.writerFileFormat = (String) parameters.get(
                 WRITER_FILE_FORMAT, WRITER_FILE_FORMAT_DEFAULT);
         this.hadoopConfig = hadoopConfig;
@@ -58,6 +61,13 @@ public class WriterConfig extends SinkConfig {
      */
     public long getWriterFlushFrequencyBytes() {
         return writerFlushFrequencyBytes;
+    }
+
+    /**
+     * Returns a long representing flush frequency by size in milliseconds.
+     */
+    public long getWriterFlushFrequencyMsec() {
+        return writerFlushFrequencyMsec;
     }
 
     /**

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
@@ -46,6 +46,16 @@ public class WriterProperties {
                     WRITER_FLUSH_FREQUENCY_BYTES_DEFAULT);
 
     /**
+     * Flush frequency by time (in milliseconds).
+     */
+    public static final String WRITER_FLUSH_FREQUENCY_MSEC = "writerFlushFrequencyMsec";
+    // TODO: Change to long.
+    public static final String WRITER_FLUSH_FREQUENCY_MSEC_DEFAULT = "60000";           // 1 min
+    public static final String WRITER_FLUSH_FREQUENCY_MSEC_DESCRIPTION =
+            String.format("Flush frequency by time in milliseconds (default: %s)",
+                    WRITER_FLUSH_FREQUENCY_MSEC_DEFAULT);
+
+    /**
      * File format for writing data files to backing Iceberg store.
      */
     public static final String WRITER_FILE_FORMAT = "writerFileFormat";

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/StageOverrideParameters.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/StageOverrideParameters.java
@@ -25,9 +25,9 @@ import io.mantisrx.connector.iceberg.sink.config.SinkProperties;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterProperties;
 import io.mantisrx.runtime.parameter.Parameters;
 
-public class WriterStageOverrideParameters {
+public class StageOverrideParameters {
 
-    private WriterStageOverrideParameters() {
+    private StageOverrideParameters() {
     }
 
     public static Parameters newParameters() {

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/WriterStageOverrideParameters.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/WriterStageOverrideParameters.java
@@ -22,11 +22,12 @@ import java.util.Map;
 import java.util.Set;
 
 import io.mantisrx.connector.iceberg.sink.config.SinkProperties;
+import io.mantisrx.connector.iceberg.sink.writer.config.WriterProperties;
 import io.mantisrx.runtime.parameter.Parameters;
 
-public class TableIdentifierParameters {
+public class WriterStageOverrideParameters {
 
-    private TableIdentifierParameters() {
+    private WriterStageOverrideParameters() {
     }
 
     public static Parameters newParameters() {
@@ -41,6 +42,9 @@ public class TableIdentifierParameters {
 
         required.add(SinkProperties.SINK_TABLE);
         state.put(SinkProperties.SINK_TABLE, "table");
+
+        required.add(WriterProperties.WRITER_FLUSH_FREQUENCY_MSEC);
+        state.put(WriterProperties.WRITER_FLUSH_FREQUENCY_MSEC, "5000");
 
         return new Parameters(state, required, required);
     }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.mantisrx.connector.iceberg.sink.TableIdentifierParameters;
+import io.mantisrx.connector.iceberg.sink.WriterStageOverrideParameters;
 import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
 import io.mantisrx.connector.iceberg.sink.committer.metrics.CommitterMetrics;
 import io.mantisrx.runtime.Context;
@@ -60,7 +60,7 @@ class IcebergCommitterStageTest {
         this.scheduler = new TestScheduler();
         this.subscriber = new TestSubscriber<>();
 
-        Parameters parameters = TableIdentifierParameters.newParameters();
+        Parameters parameters = WriterStageOverrideParameters.newParameters();
         CommitterConfig config = new CommitterConfig(parameters);
         CommitterMetrics metrics = new CommitterMetrics();
         this.committer = mock(IcebergCommitter.class);

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -50,8 +50,6 @@ class IcebergCommitterStageTest {
 
     private TestScheduler scheduler;
     private TestSubscriber<Map<String, Object>> subscriber;
-    private CommitterConfig config;
-    private CommitterMetrics metrics;
     private Catalog catalog;
     private Context context;
     private IcebergCommitter committer;
@@ -63,8 +61,8 @@ class IcebergCommitterStageTest {
         this.subscriber = new TestSubscriber<>();
 
         Parameters parameters = TableIdentifierParameters.newParameters();
-        this.config = new CommitterConfig(parameters);
-        this.metrics = new CommitterMetrics();
+        CommitterConfig config = new CommitterConfig(parameters);
+        CommitterMetrics metrics = new CommitterMetrics();
         this.committer = mock(IcebergCommitter.class);
 
         transformer = new IcebergCommitterStage.Transformer(config, metrics, committer, scheduler);

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/committer/IcebergCommitterStageTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.mantisrx.connector.iceberg.sink.WriterStageOverrideParameters;
+import io.mantisrx.connector.iceberg.sink.StageOverrideParameters;
 import io.mantisrx.connector.iceberg.sink.committer.config.CommitterConfig;
 import io.mantisrx.connector.iceberg.sink.committer.metrics.CommitterMetrics;
 import io.mantisrx.runtime.Context;
@@ -60,7 +60,7 @@ class IcebergCommitterStageTest {
         this.scheduler = new TestScheduler();
         this.subscriber = new TestSubscriber<>();
 
-        Parameters parameters = WriterStageOverrideParameters.newParameters();
+        Parameters parameters = StageOverrideParameters.newParameters();
         CommitterConfig config = new CommitterConfig(parameters);
         CommitterMetrics metrics = new CommitterMetrics();
         this.committer = mock(IcebergCommitter.class);

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -37,6 +37,7 @@ import io.mantisrx.runtime.lifecycle.ServiceLocator;
 import io.mantisrx.runtime.parameter.Parameters;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -260,7 +261,14 @@ class IcebergWriterStageTest {
 
     private static abstract class FakeIcebergWriter implements IcebergWriter {
 
+        private static final DataFile DATA_FILE = new DataFiles.Builder()
+                .withPath("/datafile.parquet")
+                .withFileSizeInBytes(1L)
+                .withRecordCount(1L)
+                .build();
+
         private final Object object;
+
         private Object fileAppender;
 
         public FakeIcebergWriter() {
@@ -276,7 +284,7 @@ class IcebergWriterStageTest {
         @Override
         public DataFile close() throws IOException {
             fileAppender = null;
-            return mock(DataFile.class);
+            return DATA_FILE;
         }
 
         @Override

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -151,7 +151,7 @@ class IcebergWriterStageTest {
     }
 
     @Test
-    void shouldNoOpCloseWhenNoDataOnTimeThreshold() throws IOException {
+    void shouldNoOpWhenNoDataOnTimeThreshold() throws IOException {
         // Low volume stream.
         Observable<Record> source = Observable.interval(10_000, TimeUnit.MILLISECONDS, scheduler)
                 .map(i -> mock(Record.class));
@@ -164,6 +164,7 @@ class IcebergWriterStageTest {
         subscriber.assertNoTerminalEvent();
 
         verify(writer, times(0)).open();
+        verify(writer, times(0)).write(any());
         verify(writer, times(2)).isClosed();
         verify(writer, times(0)).close();
     }

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -212,8 +212,8 @@ class IcebergWriterStageTest {
         subscriber.assertTerminalEvent();
 
         verify(writer).open();
-        verify(writer, times(2)).isClosed();
-        verify(writer, times(0)).close();
+        verify(writer, times(1)).isClosed();
+        verify(writer, times(1)).close();
     }
 
     @Test

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriterTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/PartitionedIcebergWriterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.connector.iceberg.sink.writer;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PartitionedIcebergWriterTest {
+
+    private static final Schema SCHEMA = new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            required(2, "str", Types.StringType.get()),
+            required(3, "bin", Types.BinaryType.get()),
+            required(4, "ts", Types.LongType.get())
+    );
+
+    private static final Record record = GenericRecord.create(SCHEMA);
+
+    @BeforeEach
+    void setUp() {
+        record.setField("id", 1);
+        record.setField("str", "foo");
+        record.setField("bin", new byte[]{});
+        record.setField("ts", System.currentTimeMillis());
+    }
+
+    @Test
+    void shouldPartition() {
+    }
+}


### PR DESCRIPTION
### Context

Adds a time-based semantic to writers to supplement size-based. Useful for low volume streams or for streams which stop emitting; effectively guarantees a maximum allowed lateness for Iceberg query recency.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
