### PR TITLE
Tune down writer row group size config.

### DIFF
--- a/mantis-connector-iceberg/README.md
+++ b/mantis-connector-iceberg/README.md
@@ -193,7 +193,7 @@ important
 
 | **Name** | **Type** | **Default** | **Description** |
 | -------- | -------- | ----------- | --------------- |
-| `writerRowGroupSize` | int | 1000 | Number of rows to chunk before checking for file size |
+| `writerRowGroupSize` | int | 100 | Number of rows to chunk before checking for file size |
 | `writerFlushFrequencyBytes` | String | "134217728" (128 MiB) | Flush frequency by size in Bytes |
 | `writerFlushFrequencyMsec` | String | "60000" (1 min) | Flush frequency by time in milliseconds |
 | `writerFileFormat` | String | parquet | File format for writing data files to backing Iceberg store |

--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterProperties.java
@@ -30,7 +30,7 @@ public class WriterProperties {
      * Maximum number of rows that should exist in a file.
      */
     public static final String WRITER_ROW_GROUP_SIZE = "writerRowGroupSize";
-    public static final int WRITER_ROW_GROUP_SIZE_DEFAULT = 1000;
+    public static final int WRITER_ROW_GROUP_SIZE_DEFAULT = 100;
     public static final String WRITER_ROW_GROUP_SIZE_DESCRIPTION =
             String.format("Number of rows to chunk before checking for file size (default: %s)",
                     WRITER_ROW_GROUP_SIZE_DEFAULT);

--- a/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
+++ b/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStageTest.java
@@ -156,15 +156,15 @@ class IcebergWriterStageTest {
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         subscriber.assertNoValues();
 
-        scheduler.advanceTimeBy(999, TimeUnit.MILLISECONDS);
+        scheduler.advanceTimeBy(99, TimeUnit.MILLISECONDS);
         subscriber.assertValueCount(1);
 
-        scheduler.advanceTimeBy(1000, TimeUnit.MILLISECONDS);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         subscriber.assertValueCount(2);
 
         subscriber.assertNoTerminalEvent();
 
-        verify(writer, times(2000)).write(any());
+        verify(writer, times(200)).write(any());
         verify(writer, times(2)).close();
     }
 
@@ -174,12 +174,12 @@ class IcebergWriterStageTest {
         flow.subscribeOn(scheduler).subscribe(subscriber);
 
         // Size is checked at row-group-size config, but under size-threshold, so no-op.
-        scheduler.advanceTimeBy(1000, TimeUnit.MILLISECONDS);
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         subscriber.assertNoValues();
 
         subscriber.assertNoTerminalEvent();
 
-        verify(writer, times(1000)).write(any());
+        verify(writer, times(100)).write(any());
         verify(writer, times(0)).close();
     }
 


### PR DESCRIPTION
### Context

From `1000` to `100`. For sufficiently-large events, a larger default
would mean the writer checks less frequently to determine if it should
flush or not. In general, we want to balance this check to in
consideration for performance.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
