### PR TITLE
Use `overwrite` and set table properties on writer.

### DIFF
--- a/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/DefaultIcebergWriter.java
+++ b/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/DefaultIcebergWriter.java
@@ -105,6 +105,8 @@ public class DefaultIcebergWriter implements IcebergWriter {
                 appender = Parquet.write(file)
                         .schema(table.schema())
                         .createWriterFunc(GenericParquetWriter::buildWriter)
+                        .setAll(table.properties())
+                        .overwrite()
                         .build();
                 break;
             case AVRO:


### PR DESCRIPTION
### Context

Prevent negative S3 caching issues which affect read-after-write consistency for S3 backends.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
